### PR TITLE
Allow RuboCop to update config during tests

### DIFF
--- a/ruby/lib/tasks/style.rake
+++ b/ruby/lib/tasks/style.rake
@@ -18,7 +18,7 @@ namespace :style do
 
   desc 'Run style checks on your diff from `master`'
   task branch: :environment do
-    RuboCop::Git::CLI.new.run(%w[--display-cop-names master])
+    exit 1 unless system('rubocop-git', '--display-cop-names', 'master')
   end
 
   desc 'Print total violation counts'


### PR DESCRIPTION
Travis is running into errors because the style task runs in the same
context as the specs. The process requires and enables WebMock so no
HTTP requests are allowed while the test suite runs.

However, if RuboCop's config drifts out of date, then it attempts to
request a new configuration file. Since it is in the same context
where network requests are not allowed, it throws an exception.

This moves the RuboCop run into its own process where HTTP requests
are allowed.