### PR TITLE
Make Hound ESLint aware

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,1 +1,7 @@
-ruby/hound.yml
+eslint:
+  enabled: true
+  config_file: config/eslint.json
+jshint:
+  enabled: false
+ruby:
+  config_file: https://raw.githubusercontent.com/apartmentlist/style/master/ruby/global.yml

--- a/config/eslint.json
+++ b/config/eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "eslint:recommended",
+  "rules": {}
+}

--- a/ruby/hound.yml
+++ b/ruby/hound.yml
@@ -1,4 +1,0 @@
-# This file is symlinked from the root of the project because that's where Hound
-# looks for .hound.yml
-ruby:
-  config_file: https://raw.githubusercontent.com/apartmentlist/style/master/ruby/global.yml


### PR DESCRIPTION
Hound is trying to run an old version of JSHint which is not
ECMAScript aware. We would like it to know about newer JavaScript
syntax, and we are fine with adhering to the community standards.