### PR TITLE
Increase the nesting allowed in specs

### DIFF
--- a/ruby/global.yml
+++ b/ruby/global.yml
@@ -48,6 +48,12 @@ RSpec/DescribeClass:
 # it's not worth changing.
 RSpec/NotToNot:
   EnforcedStyle: to_not
+  
+# The default is 3 but we'd like to be able to describe the class, give context
+# for the method being tested, and still have two contexts left to describe the
+# the tests.
+RSpec/NestedGroups:
+  Max: 4
 
 # Don't force single line blocks to name their block arguments things like
 # |a, e| for accumulator, element. Eg:


### PR DESCRIPTION
We have a situation like this right now:
```
describe EventCleaner do
  describe '.clean_up_rental_id!' do
    context 'when the rental_id has more than 100 items' do
      context 'when all items are created within the last 3 months' do
      context 'when all items are created more than 3 months ago' do
      end
    end
  end
end
```

We are describing the class being tested, giving context on the method being tested, and then we would like to have two contexts left to organize the specs. The current default is three but we think expanding this to four makes sense to be able to better describe specs.